### PR TITLE
fix a memory leak in `canopen_app_init`

### DIFF
--- a/CANopenNode_STM32/CO_app_STM32.c
+++ b/CANopenNode_STM32/CO_app_STM32.c
@@ -63,12 +63,12 @@ canopen_app_init(CANopenNodeSTM32* _canopenNodeSTM32) {
     canopenNodeSTM32 = _canopenNodeSTM32;
 
 #if (CO_CONFIG_STORAGE) & CO_CONFIG_STORAGE_ENABLE
-    CO_storage_t storage;
-    CO_storage_entry_t storageEntries[] = {{.addr = &OD_PERSIST_COMM,
-                                            .len = sizeof(OD_PERSIST_COMM),
-                                            .subIndexOD = 2,
-                                            .attr = CO_storage_cmd | CO_storage_restore,
-                                            .addrNV = NULL}};
+    static CO_storage_t storage;
+    static CO_storage_entry_t storageEntries[] = {{.addr = &OD_PERSIST_COMM,
+                                                   .len = sizeof(OD_PERSIST_COMM),
+                                                   .subIndexOD = 2,
+                                                   .attr = CO_storage_cmd | CO_storage_restore,
+                                                   .addrNV = NULL}};
     uint8_t storageEntriesCount = sizeof(storageEntries) / sizeof(storageEntries[0]);
     uint32_t storageInitError = 0;
 #endif


### PR DESCRIPTION
`storage` & `storageEntrie` are created in stack and will be released after `canopen_app_init`, while registered in `CO_storage_init`. This is definitely a problem and wasted me 2 days.