### PR TITLE
Fixed check for dual CAN device

### DIFF
--- a/CANopenNode_STM32/CO_driver_STM32.c
+++ b/CANopenNode_STM32/CO_driver_STM32.c
@@ -130,7 +130,7 @@ CO_CANmodule_init(CO_CANmodule_t* CANmodule, void* CANptr, CO_CANrx_t rxArray[],
     }
 #else
     CAN_FilterTypeDef FilterConfig;
-#if defined(CAN)
+#if !defined(CAN2)
     FilterConfig.FilterBank = 0;
 #else
     if (((CAN_HandleTypeDef*)((CANopenNodeSTM32*)CANmodule->CANptr)->CANHandle)->Instance == CAN1) {


### PR DESCRIPTION
I was having trouble getting this working on an STM32L496. I had set up CANopenNode on CAN2 and it was transmitting fine but not receiving.  After lots of debugging, I discovered this issue.

In `CO_driver_STM32`, the `FilterBank` needs to be changed depending on the CAN peripheral.  It should be `0` if using `CAN1` and `14` if using `CAN2`.  The following preprocessor switch statement looks like it's supposed to take care of this:

```c
#if defined(CAN)
    FilterConfig.FilterBank = 0;
#else
    if (((CAN_HandleTypeDef*)((CANopenNodeSTM32*)CANmodule->CANptr)->CANHandle)->Instance == CAN1) {
        FilterConfig.FilterBank = 0;
    } else {
        FilterConfig.FilterBank = 14;
    }
#endif
```

However, even in a dual-bank CAN device, `CAN` is defined.  Here is the instance in `stm32l496xx.h`:

```c
#define CAN                 ((CAN_TypeDef *) CAN1_BASE)
#define CAN1                ((CAN_TypeDef *) CAN1_BASE)
#define CAN2                ((CAN_TypeDef *) CAN2_BASE)
```

This MR changes it to check instead if `CAN2` is defined, which should work on both single-CAN and dual-CAN devices.

