### PR TITLE
Fix chicken-and-egg problem with LSS slave when running on bare metal:

### DIFF
--- a/CANopenNode_STM32/CO_app_STM32.c
+++ b/CANopenNode_STM32/CO_app_STM32.c
@@ -163,7 +163,7 @@ canopen_app_resetCommunication() {
     }
 
     err = CO_CANopenInitPDO(CO, CO->em, OD, canopenNodeSTM32->activeNodeID, &errInfo);
-    if (err != CO_ERROR_NO) {
+    if (err != CO_ERROR_NO && err != CO_ERROR_NODE_ID_UNCONFIGURED_LSS) {
         if (err == CO_ERROR_OD_PARAMETERS) {
             log_printf("Error: Object Dictionary entry 0x%X\n", errInfo);
         } else {


### PR DESCRIPTION
- CO_LSS_SWITCH_STATE_GLOBAL command to go into CO_LSS_STATE_WAITING is a no-op if active node-ID is NOT equal to 0xFF (see CO_LSSslave.c)
- CO_CANopenInitPDO() returns an error if active node-ID is equal to 0xFF
- As a result, CO_CANsetNormalMode() is never called and the CAN peripheral cannot receive data
- This prevents the LSS slave from ever changing the node-ID to or from 0xFF
- Solution is to ignore that specific error code when calling CO_CANopenInitPDO()