### PR TITLE
CO_CANsend should not increase CANtxCount if buffer is full already 

### DIFF
--- a/CANopenNode_STM32/CO_driver_STM32.c
+++ b/CANopenNode_STM32/CO_driver_STM32.c
@@ -355,8 +355,11 @@ CO_CANsend(CO_CANmodule_t* CANmodule, CO_CANtx_t* buffer) {
     if (prv_send_can_message(CANmodule, buffer)) {
         CANmodule->bufferInhibitFlag = buffer->syncFlag;
     } else {
-        buffer->bufferFull = true;
-        CANmodule->CANtxCount++;
+        /* Only increment count if buffer wasn't already full */
+        if (!buffer->bufferFull) {
+            buffer->bufferFull = true;
+            CANmodule->CANtxCount++;
+        }
     }
     CO_UNLOCK_CAN_SEND(CANmodule);
 
@@ -635,7 +638,7 @@ HAL_FDCAN_TxBufferCompleteCallback(FDCAN_HandleTypeDef* hfdcan, uint32_t BufferI
                     CANModule_local->bufferInhibitFlag = buffer->syncFlag;
                 } else {
                     break;  // if we could not send the message, break out of the loop (the tx buffers are full)
-		}
+                }
             }
         }
         CO_UNLOCK_CAN_SEND(CANModule_local);


### PR DESCRIPTION
Hi,
we had SDO Reads stall after some minutes while hammering SDO Requests with 10Hz . PDOs were still working.
Investigation in SDO-Server turned out that `CANtxCount` was 1 but `bufferFull` was still false.

HAL_FDCAN_TxBufferCompleteCallback sends buffer only once if buffer was full, so we can do `CANtxCount++` only once.

MCU was STM32G473.
This took me some time. Gemini und Claude figured it out in seconds :unamused:

Also fixes tabs indentation.

This issues should also be fixed in [CO_driver_blank.c](https://github.com/CANopenNode/CANopenNode/blob/145a15d9449a701c911caa19e98b2f029286da53/example/CO_driver_blank.c#L169) i guess? @CANopenNode 

regards Simon

