### PR TITLE
Use `PRIu32`/`PRIx32` macros instead of harcoded `%u`/`%X` specifiers in format strings

### DIFF
--- a/CANopenNode_STM32/CO_app_STM32.c
+++ b/CANopenNode_STM32/CO_app_STM32.c
@@ -28,6 +28,7 @@
 #include "CANopen.h"
 #include "main.h"
 #include <stdio.h>
+#include <inttypes.h>
 
 #include "CO_storageBlank.h"
 #include "OD.h"
@@ -90,7 +91,7 @@ canopen_app_init(CANopenNodeSTM32* _canopenNodeSTM32) {
         log_printf("Error: Can't allocate memory\n");
         return 1;
     } else {
-        log_printf("Allocated %u bytes for CANopen objects\n", heapMemoryUsed);
+        log_printf("Allocated %" PRIu32 " bytes for CANopen objects\n", heapMemoryUsed);
     }
 
     canopenNodeSTM32->canOpenStack = CO;
@@ -155,7 +156,7 @@ canopen_app_resetCommunication() {
                          canopenNodeSTM32->activeNodeID, &errInfo);
     if (err != CO_ERROR_NO && err != CO_ERROR_NODE_ID_UNCONFIGURED_LSS) {
         if (err == CO_ERROR_OD_PARAMETERS) {
-            log_printf("Error: Object Dictionary entry 0x%X\n", errInfo);
+            log_printf("Error: Object Dictionary entry 0x%" PRIx32 "\n", errInfo);
         } else {
             log_printf("Error: CANopen initialization failed: %d\n", err);
         }
@@ -165,7 +166,7 @@ canopen_app_resetCommunication() {
     err = CO_CANopenInitPDO(CO, CO->em, OD, canopenNodeSTM32->activeNodeID, &errInfo);
     if (err != CO_ERROR_NO && err != CO_ERROR_NODE_ID_UNCONFIGURED_LSS) {
         if (err == CO_ERROR_OD_PARAMETERS) {
-            log_printf("Error: Object Dictionary entry 0x%X\n", errInfo);
+            log_printf("Error: Object Dictionary entry 0x%" PRIx32 "\n", errInfo);
         } else {
             log_printf("Error: PDO initialization failed: %d\n", err);
         }


### PR DESCRIPTION
We are not able to build with `-Werror=format` flag due to warnings about some string format specifiers mismatch (`%u` vs `%lu`). 

This PR fixes the problem by replacing `%u`/`%X` specifiers with more portable `PRIu32`/`PRIx32` ones.