### PR TITLE
CAN: Update FDCAN message format to support FD CAN with bitrate swithing

### DIFF
--- a/CANopenNode_STM32/CO_driver_STM32.c
+++ b/CANopenNode_STM32/CO_driver_STM32.c
@@ -264,8 +264,8 @@ prv_send_can_message(CO_CANmodule_t* CANmodule, CO_CANtx_t* buffer) {
         tx_hdr.Identifier = buffer->ident & CANID_MASK;
         tx_hdr.TxFrameType = (buffer->ident & FLAG_RTR) ? FDCAN_REMOTE_FRAME : FDCAN_DATA_FRAME;
         tx_hdr.IdType = FDCAN_STANDARD_ID;
-        tx_hdr.FDFormat = FDCAN_CLASSIC_CAN;
-        tx_hdr.BitRateSwitch = FDCAN_BRS_OFF;
+        tx_hdr.FDFormat = FDCAN_FD_CAN;
+        tx_hdr.BitRateSwitch = FDCAN_BRS_ON;
         tx_hdr.MessageMarker = 0;
         tx_hdr.ErrorStateIndicator = FDCAN_ESI_ACTIVE;
         tx_hdr.TxEventFifoControl = FDCAN_NO_TX_EVENTS;


### PR DESCRIPTION
This pull request updates the CAN message transmission configuration to enable CAN FD mode with bit rate switching. The change ensures that messages are sent using the CAN FD protocol, which allows for higher data rates and improved performance.

CAN FD mode activation:

* Changed the `FDFormat` field in the `tx_hdr` struct from `FDCAN_CLASSIC_CAN` to `FDCAN_FD_CAN`, enabling CAN FD protocol for message transmission.
* Set the `BitRateSwitch` field to `FDCAN_BRS_ON` instead of `FDCAN_BRS_OFF`, allowing bit rate switching for faster data transfer in CAN FD mode.