### PR TITLE
CO_driver_STM32: optional FreeRTOS implementation of the CO_LOCK_* - 

### DIFF
--- a/CANopenNode_STM32/CO_driver_locks_freertos.h
+++ b/CANopenNode_STM32/CO_driver_locks_freertos.h
@@ -1,0 +1,69 @@
+/*
+ * FreeRTOS critical sections for the CANopenNode CO_LOCK_* macros.
+ *
+ * Include from CO_driver_custom.h 
+ * The defaults in CO_driver_target.h are #ifndef-guarded, so no #undef is needed.
+ *
+ * @file        CO_driver_locks_freertos.h
+ * @author      Danial Keshavarzi    2026
+ * @copyright   2026 Danial Keshavarzi
+ *
+ * This file is part of CANopenNode, an opensource CANopen Stack.
+ * Project home page is <https://github.com/CANopenNode/CANopenNode>.
+ * For more information on CANopen see <http://www.can-cia.org/>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef CO_DRIVER_LOCKS_FREERTOS_H
+#define CO_DRIVER_LOCKS_FREERTOS_H
+
+#include "FreeRTOS.h"
+#include "task.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline UBaseType_t
+CO_STM32_enterCritical(void) {
+    if (__get_IPSR() == 0U) {
+        taskENTER_CRITICAL();
+        return 0U;
+    }
+    return taskENTER_CRITICAL_FROM_ISR();
+}
+
+static inline void
+CO_STM32_exitCritical(UBaseType_t saved) {
+    if (__get_IPSR() == 0U) {
+        taskEXIT_CRITICAL();
+    } else {
+        taskEXIT_CRITICAL_FROM_ISR(saved);
+    }
+}
+
+/* LOCK declares the state that UNLOCK consumes; both must be in the same scope. */
+#define CO_LOCK_CAN_SEND(CAN_MODULE)   UBaseType_t coLockStateSend = CO_STM32_enterCritical()
+#define CO_UNLOCK_CAN_SEND(CAN_MODULE) CO_STM32_exitCritical(coLockStateSend)
+
+#define CO_LOCK_EMCY(CAN_MODULE)       UBaseType_t coLockStateEmcy = CO_STM32_enterCritical()
+#define CO_UNLOCK_EMCY(CAN_MODULE)     CO_STM32_exitCritical(coLockStateEmcy)
+
+#define CO_LOCK_OD(CAN_MODULE)         UBaseType_t coLockStateOd = CO_STM32_enterCritical()
+#define CO_UNLOCK_OD(CAN_MODULE)       CO_STM32_exitCritical(coLockStateOd)
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* CO_DRIVER_LOCKS_FREERTOS_H */

--- a/CANopenNode_STM32/CO_driver_target.h
+++ b/CANopenNode_STM32/CO_driver_target.h
@@ -136,6 +136,8 @@ typedef struct {
     void* addrNV;
 } CO_storage_entry_t;
 
+/* Skipped if a custom driver header (CO_DRIVER_CUSTOM) already defined CO_LOCK_CAN_SEND */
+#ifndef CO_LOCK_CAN_SEND
 /* (un)lock critical section in CO_CANsend() */
 // Why disabling the whole Interrupt
 #define CO_LOCK_CAN_SEND(CAN_MODULE)                                                                                   \
@@ -160,6 +162,7 @@ typedef struct {
         __disable_irq();                                                                                               \
     } while (0)
 #define CO_UNLOCK_OD(CAN_MODULE) __set_PRIMASK((CAN_MODULE)->primask_od)
+#endif /* CO_LOCK_CAN_SEND */
 
 /* Synchronization between CAN receive and message processing threads. */
 #define CO_MemoryBarrier()


### PR DESCRIPTION
-macros

The default CO_LOCK_* macros disable all interrupts via __disable_irq(). Under a preemptive RTOS that is heavier than necessary and also masks interrupts above configMAX_SYSCALL_INTERRUPT_PRIORITY.

Add CO_driver_locks_freertos.h implementing the six lock/unlock macros with taskENTER_CRITICAL() / taskENTER_CRITICAL_FROM_ISR(), selected at runtime with __get_IPSR().

#ifndef added around the default CO_LOCK_* macros in the CO_driver_target.h to only use them when there isn't any,