### PR TITLE
IRQ: Use local variables for primask

### DIFF
--- a/CANopenNode_STM32/CO_driver_target.h
+++ b/CANopenNode_STM32/CO_driver_target.h
@@ -119,11 +119,6 @@ typedef struct {
     volatile uint16_t CANtxCount;
     uint32_t errOld;
 
-    /* STM32 specific features */
-    uint32_t primask_send; /* Primask register for interrupts for send operation */
-    uint32_t primask_emcy; /* Primask register for interrupts for emergency operation */
-    uint32_t primask_od;   /* Primask register for interrupts for send operation */
-
 } CO_CANmodule_t;
 
 /* Data storage object for one entry */
@@ -140,26 +135,32 @@ typedef struct {
 // Why disabling the whole Interrupt
 #define CO_LOCK_CAN_SEND(CAN_MODULE)                                                                                   \
     do {                                                                                                               \
-        (CAN_MODULE)->primask_send = __get_PRIMASK();                                                                  \
-        __disable_irq();                                                                                               \
-    } while (0)
-#define CO_UNLOCK_CAN_SEND(CAN_MODULE) __set_PRIMASK((CAN_MODULE)->primask_send)
+        uint32_t primask_send = __get_PRIMASK();                                                                       \
+        __disable_irq();
+#define CO_UNLOCK_CAN_SEND(CAN_MODULE)                                                                                 \
+    __set_PRIMASK(primask_send);                                                                                       \
+    }                                                                                                                  \
+    while (0)
 
 /* (un)lock critical section in CO_errorReport() or CO_errorReset() */
 #define CO_LOCK_EMCY(CAN_MODULE)                                                                                       \
     do {                                                                                                               \
-        (CAN_MODULE)->primask_emcy = __get_PRIMASK();                                                                  \
-        __disable_irq();                                                                                               \
-    } while (0)
-#define CO_UNLOCK_EMCY(CAN_MODULE) __set_PRIMASK((CAN_MODULE)->primask_emcy)
+        uint32_t primask_emcy = __get_PRIMASK();                                                                       \
+        __disable_irq();
+#define CO_UNLOCK_EMCY(CAN_MODULE)                                                                                     \
+    __set_PRIMASK(primask_emcy);                                                                                       \
+    }                                                                                                                  \
+    while (0)
 
 /* (un)lock critical section when accessing Object Dictionary */
 #define CO_LOCK_OD(CAN_MODULE)                                                                                         \
     do {                                                                                                               \
-        (CAN_MODULE)->primask_od = __get_PRIMASK();                                                                    \
-        __disable_irq();                                                                                               \
-    } while (0)
-#define CO_UNLOCK_OD(CAN_MODULE) __set_PRIMASK((CAN_MODULE)->primask_od)
+        uint32_t primask_od = __get_PRIMASK();                                                                         \
+        __disable_irq();
+#define CO_UNLOCK_OD(CAN_MODULE)                                                                                       \
+    __set_PRIMASK(primask_od);                                                                                         \
+    }                                                                                                                  \
+    while (0)
 
 /* Synchronization between CAN receive and message processing threads. */
 #define CO_MemoryBarrier()
@@ -174,7 +175,6 @@ typedef struct {
         CO_MemoryBarrier();                                                                                            \
         rxNew = NULL;                                                                                                  \
     } while (0)
-
 
 #ifdef __cplusplus
 }

--- a/examples/stm32g0xx_fdcan/CMakeLists.txt
+++ b/examples/stm32g0xx_fdcan/CMakeLists.txt
@@ -12,6 +12,7 @@ file(GLOB_RECURSE files_SRCS
     ${CMAKE_CURRENT_LIST_DIR}/Core/Startup/*.s
     ${CMAKE_CURRENT_LIST_DIR}/Drivers/STM32G0xx_HAL_Driver/Src/*.c
     ${CMAKE_CURRENT_LIST_DIR}/../../CANopenNode_STM32/*.c
+    ${CMAKE_CURRENT_LIST_DIR}/../general/*.c
 )
 file(GLOB_RECURSE canopennode_SRCS
     ${CMAKE_CURRENT_LIST_DIR}/../../CANopenNode/*.c
@@ -32,6 +33,7 @@ set(include_DIRS ${include_DIRS}
     ${CMAKE_CURRENT_LIST_DIR}/Drivers/CMSIS/Include
     ${CMAKE_CURRENT_LIST_DIR}/../../CANopenNode
     ${CMAKE_CURRENT_LIST_DIR}/../../CANopenNode_STM32
+    ${CMAKE_CURRENT_LIST_DIR}/../general
 )
 
 # Symbols for compilation


### PR DESCRIPTION
This PR fixes the use of global variables (that can be overwritten) with the local variables. It also implements the do-while method that will force the compiler error when the lock/unlock is misused or forgotten.

In the same PR, we also fix the G0xx example to support new repository org of the OD file in the general example.