### PR TITLE
cmake build system

### DIFF
--- a/CANopenNode_STM32/CO_driver_target.h
+++ b/CANopenNode_STM32/CO_driver_target.h
@@ -119,11 +119,6 @@ typedef struct {
     volatile uint16_t CANtxCount;
     uint32_t errOld;
 
-    /* STM32 specific features */
-    uint32_t primask_send; /* Primask register for interrupts for send operation */
-    uint32_t primask_emcy; /* Primask register for interrupts for emergency operation */
-    uint32_t primask_od;   /* Primask register for interrupts for send operation */
-
 } CO_CANmodule_t;
 
 /* Data storage object for one entry */
@@ -140,26 +135,32 @@ typedef struct {
 // Why disabling the whole Interrupt
 #define CO_LOCK_CAN_SEND(CAN_MODULE)                                                                                   \
     do {                                                                                                               \
-        (CAN_MODULE)->primask_send = __get_PRIMASK();                                                                  \
-        __disable_irq();                                                                                               \
-    } while (0)
-#define CO_UNLOCK_CAN_SEND(CAN_MODULE) __set_PRIMASK((CAN_MODULE)->primask_send)
+        uint32_t primask_send = __get_PRIMASK();                                                                       \
+        __disable_irq();
+#define CO_UNLOCK_CAN_SEND(CAN_MODULE)                                                                                 \
+    __set_PRIMASK(primask_send);                                                                                       \
+    }                                                                                                                  \
+    while (0)
 
 /* (un)lock critical section in CO_errorReport() or CO_errorReset() */
 #define CO_LOCK_EMCY(CAN_MODULE)                                                                                       \
     do {                                                                                                               \
-        (CAN_MODULE)->primask_emcy = __get_PRIMASK();                                                                  \
-        __disable_irq();                                                                                               \
-    } while (0)
-#define CO_UNLOCK_EMCY(CAN_MODULE) __set_PRIMASK((CAN_MODULE)->primask_emcy)
+        uint32_t primask_emcy = __get_PRIMASK();                                                                       \
+        __disable_irq();
+#define CO_UNLOCK_EMCY(CAN_MODULE)                                                                                     \
+    __set_PRIMASK(primask_emcy);                                                                                       \
+    }                                                                                                                  \
+    while (0)
 
 /* (un)lock critical section when accessing Object Dictionary */
 #define CO_LOCK_OD(CAN_MODULE)                                                                                         \
     do {                                                                                                               \
-        (CAN_MODULE)->primask_od = __get_PRIMASK();                                                                    \
-        __disable_irq();                                                                                               \
-    } while (0)
-#define CO_UNLOCK_OD(CAN_MODULE) __set_PRIMASK((CAN_MODULE)->primask_od)
+        uint32_t primask_od = __get_PRIMASK();                                                                         \
+        __disable_irq();
+#define CO_UNLOCK_OD(CAN_MODULE)                                                                                       \
+    __set_PRIMASK(primask_od);                                                                                         \
+    }                                                                                                                  \
+    while (0)
 
 /* Synchronization between CAN receive and message processing threads. */
 #define CO_MemoryBarrier()
@@ -174,7 +175,6 @@ typedef struct {
         CO_MemoryBarrier();                                                                                            \
         rxNew = NULL;                                                                                                  \
     } while (0)
-
 
 #ifdef __cplusplus
 }

--- a/examples/stm32g0xx_fdcan/CMakeLists.txt
+++ b/examples/stm32g0xx_fdcan/CMakeLists.txt
@@ -12,6 +12,7 @@ file(GLOB_RECURSE files_SRCS
     ${CMAKE_CURRENT_LIST_DIR}/Core/Startup/*.s
     ${CMAKE_CURRENT_LIST_DIR}/Drivers/STM32G0xx_HAL_Driver/Src/*.c
     ${CMAKE_CURRENT_LIST_DIR}/../../CANopenNode_STM32/*.c
+    ${CMAKE_CURRENT_LIST_DIR}/../general/*.c
 )
 file(GLOB_RECURSE canopennode_SRCS
     ${CMAKE_CURRENT_LIST_DIR}/../../CANopenNode/*.c
@@ -32,6 +33,7 @@ set(include_DIRS ${include_DIRS}
     ${CMAKE_CURRENT_LIST_DIR}/Drivers/CMSIS/Include
     ${CMAKE_CURRENT_LIST_DIR}/../../CANopenNode
     ${CMAKE_CURRENT_LIST_DIR}/../../CANopenNode_STM32
+    ${CMAKE_CURRENT_LIST_DIR}/../general
 )
 
 # Symbols for compilation

--- a/examples/stm32g0xx_fdcan_rtos/CMakeLists.txt
+++ b/examples/stm32g0xx_fdcan_rtos/CMakeLists.txt
@@ -1,0 +1,83 @@
+cmake_minimum_required(VERSION 3.19)
+
+project(stm32g0xx_fdcan_rtos)
+enable_language(C CXX ASM)
+
+# Linker and startup goes here
+set(linker_script_SRC ${CMAKE_CURRENT_LIST_DIR}/STM32G0C1VETX_FLASH.ld)
+
+# Application, HAL driver and CANopenNode sources
+file(GLOB_RECURSE files_SRCS
+    ${CMAKE_CURRENT_LIST_DIR}/Core/Src/*.c
+    ${CMAKE_CURRENT_LIST_DIR}/Core/Startup/*.s
+    ${CMAKE_CURRENT_LIST_DIR}/Drivers/STM32G0xx_HAL_Driver/Src/*.c
+    ${CMAKE_CURRENT_LIST_DIR}/Middlewares/Third_Party/FreeRTOS/Source/*.c
+    ${CMAKE_CURRENT_LIST_DIR}/../../CANopenNode_STM32/*.c
+    ${CMAKE_CURRENT_LIST_DIR}/../general/*.c
+)
+file(GLOB_RECURSE canopennode_SRCS
+    ${CMAKE_CURRENT_LIST_DIR}/../../CANopenNode/*.c
+)
+
+# Ignore the actual example folder in the CanOpenNode object
+list(FILTER canopennode_SRCS EXCLUDE REGEX "/CANopenNode/example/")
+
+# Merge the sources
+set(files_SRCS ${files_SRCS} ${canopennode_SRCS})
+
+# Include directories
+set(include_DIRS ${include_DIRS}
+    ${CMAKE_CURRENT_LIST_DIR}/Core/Inc
+    ${CMAKE_CURRENT_LIST_DIR}/Drivers/STM32G0xx_HAL_Driver/Inc
+    ${CMAKE_CURRENT_LIST_DIR}/Drivers/STM32G0xx_HAL_Driver/Inc/Legacy
+    ${CMAKE_CURRENT_LIST_DIR}/Drivers/CMSIS/Device/ST/STM32G0xx/Include
+    ${CMAKE_CURRENT_LIST_DIR}/Drivers/CMSIS/Include
+    ${CMAKE_CURRENT_LIST_DIR}/Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS_V2
+    ${CMAKE_CURRENT_LIST_DIR}/Middlewares/Third_Party/FreeRTOS/Source/include
+    ${CMAKE_CURRENT_LIST_DIR}/Middlewares/Third_Party/FreeRTOS/Source/portable/GCC/ARM_CM0
+    ${CMAKE_CURRENT_LIST_DIR}/../../CANopenNode
+    ${CMAKE_CURRENT_LIST_DIR}/../../CANopenNode_STM32
+    ${CMAKE_CURRENT_LIST_DIR}/../general
+)
+
+# Symbols for compilation
+set(symbols_SYMB ${symbols_SYMB}
+    "DEBUG"
+    "STM32G0C1xx"
+    "USE_HAL_DRIVER"
+)
+
+# Core MCU flags, CPU, instruction set and FPU setup
+# Set the global compilation flags for all units
+include(${CMAKE_CURRENT_LIST_DIR}/../../cmake/compiler-flags-cortex-m0p.cmake)
+
+# Add executable
+add_executable(${CMAKE_PROJECT_NAME})
+target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC ${symbols_SYMB})
+target_include_directories(${CMAKE_PROJECT_NAME} PUBLIC ${include_DIRS})
+target_sources(${CMAKE_PROJECT_NAME} PUBLIC ${files_SRCS})
+
+# Setup linker parameters
+target_link_options(${CMAKE_PROJECT_NAME} PRIVATE
+    -T${linker_script_SRC}
+    ${cpu_PARAMS}
+    -Wl,-Map=${CMAKE_PROJECT_NAME}.map
+
+    -Wl,--start-group
+    -lc
+    -lm
+
+    -lstdc++
+    -lsupc++
+    -Wl,--end-group
+    -Wl,-z,max-page-size=8 # Allow good software remapping across address space (with proper GCC section making)
+    -Wl,--print-memory-usage
+)
+
+# Output files in the build folder
+set(BUILD_OUTPUT_DIR ${CMAKE_CURRENT_LIST_DIR}/../../_build_outputs)
+add_custom_command(TARGET ${CMAKE_PROJECT_NAME} POST_BUILD
+    COMMAND ${CMAKE_SIZE} $<TARGET_FILE:${CMAKE_PROJECT_NAME}>
+    COMMAND ${CMAKE_OBJCOPY} -O ihex $<TARGET_FILE:${CMAKE_PROJECT_NAME}> $<TARGET_FILE_DIR:${CMAKE_PROJECT_NAME}>/${CMAKE_PROJECT_NAME}.hex
+    COMMAND ${CMAKE_OBJCOPY} -O binary $<TARGET_FILE:${CMAKE_PROJECT_NAME}> $<TARGET_FILE_DIR:${CMAKE_PROJECT_NAME}>/${CMAKE_PROJECT_NAME}.bin
+)

--- a/examples/stm32g0xx_fdcan_rtos/CMakePresets.json
+++ b/examples/stm32g0xx_fdcan_rtos/CMakePresets.json
@@ -1,0 +1,27 @@
+{
+    "version": 3,
+    "configurePresets": [
+        {
+            "name": "default",
+            "hidden": true,
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build/${presetName}",
+            "toolchainFile": "${sourceDir}/../../cmake/gcc-arm-none-eabi.cmake",
+            "cacheVariables": {
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "name": "stm32g0xx_fdcan_rtos",
+            "inherits": "default",
+            "cacheVariables": {}
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "stm32g0xx_fdcan_rtos",
+            "configurePreset": "stm32g0xx_fdcan_rtos"
+        }
+    ]
+}

--- a/examples/stm32h7xx_fdcan/CMakeLists.txt
+++ b/examples/stm32h7xx_fdcan/CMakeLists.txt
@@ -1,0 +1,79 @@
+cmake_minimum_required(VERSION 3.19)
+
+project(stm32h7xx_fdcan)
+enable_language(C CXX ASM)
+
+# Linker and startup goes here
+set(linker_script_SRC ${CMAKE_CURRENT_LIST_DIR}/STM32H735IGKX_FLASH.ld)
+
+# Application, HAL driver and CANopenNode sources
+file(GLOB_RECURSE files_SRCS
+    ${CMAKE_CURRENT_LIST_DIR}/Core/Src/*.c
+    ${CMAKE_CURRENT_LIST_DIR}/Core/Startup/*.s
+    ${CMAKE_CURRENT_LIST_DIR}/Drivers/STM32H7xx_HAL_Driver/Src/*.c
+    ${CMAKE_CURRENT_LIST_DIR}/../../CANopenNode_STM32/*.c
+    ${CMAKE_CURRENT_LIST_DIR}/../general/*.c
+)
+file(GLOB_RECURSE canopennode_SRCS
+    ${CMAKE_CURRENT_LIST_DIR}/../../CANopenNode/*.c
+)
+
+# Ignore the actual example folder in the CanOpenNode object
+list(FILTER canopennode_SRCS EXCLUDE REGEX "/CANopenNode/example/")
+
+# Merge the sources
+set(files_SRCS ${files_SRCS} ${canopennode_SRCS})
+
+# Include directories
+set(include_DIRS ${include_DIRS}
+    ${CMAKE_CURRENT_LIST_DIR}/Core/Inc
+    ${CMAKE_CURRENT_LIST_DIR}/Drivers/STM32H7xx_HAL_Driver/Inc
+    ${CMAKE_CURRENT_LIST_DIR}/Drivers/STM32H7xx_HAL_Driver/Inc/Legacy
+    ${CMAKE_CURRENT_LIST_DIR}/Drivers/CMSIS/Device/ST/STM32H7xx/Include
+    ${CMAKE_CURRENT_LIST_DIR}/Drivers/CMSIS/Include
+    ${CMAKE_CURRENT_LIST_DIR}/../../CANopenNode
+    ${CMAKE_CURRENT_LIST_DIR}/../../CANopenNode_STM32
+    ${CMAKE_CURRENT_LIST_DIR}/../general
+)
+
+# Symbols for compilation
+set(symbols_SYMB ${symbols_SYMB}
+    "DEBUG"
+    "STM32H735xx"
+    "USE_HAL_DRIVER"
+)
+
+# Core MCU flags, CPU, instruction set and FPU setup
+# Set the global compilation flags for all units
+include(${CMAKE_CURRENT_LIST_DIR}/../../cmake/compiler-flags-cortex-m7.cmake)
+
+# Add executable
+add_executable(${CMAKE_PROJECT_NAME})
+target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC ${symbols_SYMB})
+target_include_directories(${CMAKE_PROJECT_NAME} PUBLIC ${include_DIRS})
+target_sources(${CMAKE_PROJECT_NAME} PUBLIC ${files_SRCS})
+
+# Setup linker parameters
+target_link_options(${CMAKE_PROJECT_NAME} PRIVATE
+    -T${linker_script_SRC}
+    ${cpu_PARAMS}
+    -Wl,-Map=${CMAKE_PROJECT_NAME}.map
+
+    -Wl,--start-group
+    -lc
+    -lm
+
+    -lstdc++
+    -lsupc++
+    -Wl,--end-group
+    -Wl,-z,max-page-size=8 # Allow good software remapping across address space (with proper GCC section making)
+    -Wl,--print-memory-usage
+)
+
+# Output files in the build folder
+set(BUILD_OUTPUT_DIR ${CMAKE_CURRENT_LIST_DIR}/../../_build_outputs)
+add_custom_command(TARGET ${CMAKE_PROJECT_NAME} POST_BUILD
+    COMMAND ${CMAKE_SIZE} $<TARGET_FILE:${CMAKE_PROJECT_NAME}>
+    COMMAND ${CMAKE_OBJCOPY} -O ihex $<TARGET_FILE:${CMAKE_PROJECT_NAME}> $<TARGET_FILE_DIR:${CMAKE_PROJECT_NAME}>/${CMAKE_PROJECT_NAME}.hex
+    COMMAND ${CMAKE_OBJCOPY} -O binary $<TARGET_FILE:${CMAKE_PROJECT_NAME}> $<TARGET_FILE_DIR:${CMAKE_PROJECT_NAME}>/${CMAKE_PROJECT_NAME}.bin
+)

--- a/examples/stm32h7xx_fdcan/CMakePresets.json
+++ b/examples/stm32h7xx_fdcan/CMakePresets.json
@@ -1,0 +1,27 @@
+{
+    "version": 3,
+    "configurePresets": [
+        {
+            "name": "default",
+            "hidden": true,
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build/${presetName}",
+            "toolchainFile": "${sourceDir}/../../cmake/gcc-arm-none-eabi.cmake",
+            "cacheVariables": {
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "name": "stm32h7xx_fdcan",
+            "inherits": "default",
+            "cacheVariables": {}
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "stm32h7xx_fdcan",
+            "configurePreset": "stm32h7xx_fdcan"
+        }
+    ]
+}


### PR DESCRIPTION
Adds the cmake build system from the existing STM32CubeIDE projects. Projects were parsed and ensured the same project compiles correctly.

This will help as a next step to support docker build on every PR to verify repository build correctly before we merge.