### PR TITLE
CMAKE: add cmake build for all remaining examples

### DIFF
--- a/cmake/compiler-flags-cortex-m0.cmake
+++ b/cmake/compiler-flags-cortex-m0.cmake
@@ -1,0 +1,2 @@
+set(cpu_PARAMS -mthumb -mcpu=cortex-m0 -mfloat-abi=soft)
+include(${CMAKE_CURRENT_LIST_DIR}/compiler-flags-cortex-common.cmake)

--- a/examples/stm32f0xx_can/CMakeLists.txt
+++ b/examples/stm32f0xx_can/CMakeLists.txt
@@ -1,0 +1,79 @@
+cmake_minimum_required(VERSION 3.19)
+
+project(stm32f0xx_can)
+enable_language(C CXX ASM)
+
+# Linker and startup goes here
+set(linker_script_SRC ${CMAKE_CURRENT_LIST_DIR}/STM32F072RBTX_FLASH.ld)
+
+# Application, HAL driver and CANopenNode sources
+file(GLOB_RECURSE files_SRCS
+    ${CMAKE_CURRENT_LIST_DIR}/Core/Src/*.c
+    ${CMAKE_CURRENT_LIST_DIR}/Core/Startup/*.s
+    ${CMAKE_CURRENT_LIST_DIR}/Drivers/STM32F0xx_HAL_Driver/Src/*.c
+    ${CMAKE_CURRENT_LIST_DIR}/../../CANopenNode_STM32/*.c
+    ${CMAKE_CURRENT_LIST_DIR}/../general/*.c
+)
+file(GLOB_RECURSE canopennode_SRCS
+    ${CMAKE_CURRENT_LIST_DIR}/../../CANopenNode/*.c
+)
+
+# Ignore the actual example folder in the CanOpenNode object
+list(FILTER canopennode_SRCS EXCLUDE REGEX "/CANopenNode/example/")
+
+# Merge the sources
+set(files_SRCS ${files_SRCS} ${canopennode_SRCS})
+
+# Include directories
+set(include_DIRS ${include_DIRS}
+    ${CMAKE_CURRENT_LIST_DIR}/Core/Inc
+    ${CMAKE_CURRENT_LIST_DIR}/Drivers/STM32F0xx_HAL_Driver/Inc
+    ${CMAKE_CURRENT_LIST_DIR}/Drivers/STM32F0xx_HAL_Driver/Inc/Legacy
+    ${CMAKE_CURRENT_LIST_DIR}/Drivers/CMSIS/Device/ST/STM32F0xx/Include
+    ${CMAKE_CURRENT_LIST_DIR}/Drivers/CMSIS/Include
+    ${CMAKE_CURRENT_LIST_DIR}/../../CANopenNode
+    ${CMAKE_CURRENT_LIST_DIR}/../../CANopenNode_STM32
+    ${CMAKE_CURRENT_LIST_DIR}/../general
+)
+
+# Symbols for compilation
+set(symbols_SYMB ${symbols_SYMB}
+    "DEBUG"
+    "STM32F072xB"
+    "USE_HAL_DRIVER"
+)
+
+# Core MCU flags, CPU, instruction set and FPU setup
+# Set the global compilation flags for all units
+include(${CMAKE_CURRENT_LIST_DIR}/../../cmake/compiler-flags-cortex-m0.cmake)
+
+# Add executable
+add_executable(${CMAKE_PROJECT_NAME})
+target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC ${symbols_SYMB})
+target_include_directories(${CMAKE_PROJECT_NAME} PUBLIC ${include_DIRS})
+target_sources(${CMAKE_PROJECT_NAME} PUBLIC ${files_SRCS})
+
+# Setup linker parameters
+target_link_options(${CMAKE_PROJECT_NAME} PRIVATE
+    -T${linker_script_SRC}
+    ${cpu_PARAMS}
+    -Wl,-Map=${CMAKE_PROJECT_NAME}.map
+
+    -Wl,--start-group
+    -lc
+    -lm
+
+    -lstdc++
+    -lsupc++
+    -Wl,--end-group
+    -Wl,-z,max-page-size=8 # Allow good software remapping across address space (with proper GCC section making)
+    -Wl,--print-memory-usage
+)
+
+# Output files in the build folder
+set(BUILD_OUTPUT_DIR ${CMAKE_CURRENT_LIST_DIR}/../../_build_outputs)
+add_custom_command(TARGET ${CMAKE_PROJECT_NAME} POST_BUILD
+    COMMAND ${CMAKE_SIZE} $<TARGET_FILE:${CMAKE_PROJECT_NAME}>
+    COMMAND ${CMAKE_OBJCOPY} -O ihex $<TARGET_FILE:${CMAKE_PROJECT_NAME}> $<TARGET_FILE_DIR:${CMAKE_PROJECT_NAME}>/${CMAKE_PROJECT_NAME}.hex
+    COMMAND ${CMAKE_OBJCOPY} -O binary $<TARGET_FILE:${CMAKE_PROJECT_NAME}> $<TARGET_FILE_DIR:${CMAKE_PROJECT_NAME}>/${CMAKE_PROJECT_NAME}.bin
+)

--- a/examples/stm32f0xx_can/CMakePresets.json
+++ b/examples/stm32f0xx_can/CMakePresets.json
@@ -1,0 +1,27 @@
+{
+    "version": 3,
+    "configurePresets": [
+        {
+            "name": "default",
+            "hidden": true,
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build/${presetName}",
+            "toolchainFile": "${sourceDir}/../../cmake/gcc-arm-none-eabi.cmake",
+            "cacheVariables": {
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "name": "stm32f0xx_can",
+            "inherits": "default",
+            "cacheVariables": {}
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "stm32f0xx_can",
+            "configurePreset": "stm32f0xx_can"
+        }
+    ]
+}

--- a/examples/stm32f3xx_can/CMakeLists.txt
+++ b/examples/stm32f3xx_can/CMakeLists.txt
@@ -1,0 +1,80 @@
+cmake_minimum_required(VERSION 3.19)
+
+project(stm32f3xx_can)
+enable_language(C CXX ASM)
+
+# Linker and startup goes here
+set(linker_script_SRC ${CMAKE_CURRENT_LIST_DIR}/STM32F303ZETX_FLASH.ld)
+
+# Application, HAL driver and CANopenNode sources
+file(GLOB_RECURSE files_SRCS
+    ${CMAKE_CURRENT_LIST_DIR}/Core/Src/*.c
+    ${CMAKE_CURRENT_LIST_DIR}/Core/Startup/*.s
+    ${CMAKE_CURRENT_LIST_DIR}/Drivers/STM32F3xx_HAL_Driver/Src/*.c
+    ${CMAKE_CURRENT_LIST_DIR}/../../CANopenNode_STM32/*.c
+    ${CMAKE_CURRENT_LIST_DIR}/../general/*.c
+)
+file(GLOB_RECURSE canopennode_SRCS
+    ${CMAKE_CURRENT_LIST_DIR}/../../CANopenNode/*.c
+)
+
+# Ignore the actual example folder in the CanOpenNode object
+list(FILTER canopennode_SRCS EXCLUDE REGEX "/CANopenNode/example/")
+
+# Merge the sources
+set(files_SRCS ${files_SRCS} ${canopennode_SRCS})
+
+# Include directories
+set(include_DIRS ${include_DIRS}
+    ${CMAKE_CURRENT_LIST_DIR}/Core/Inc
+    ${CMAKE_CURRENT_LIST_DIR}/Drivers/STM32F3xx_HAL_Driver/Inc
+    ${CMAKE_CURRENT_LIST_DIR}/Drivers/STM32F3xx_HAL_Driver/Inc/Legacy
+    ${CMAKE_CURRENT_LIST_DIR}/Drivers/CMSIS/Device/ST/STM32F3xx/Include
+    ${CMAKE_CURRENT_LIST_DIR}/Drivers/CMSIS/Include
+    ${CMAKE_CURRENT_LIST_DIR}/../../CANopenNode
+    ${CMAKE_CURRENT_LIST_DIR}/../../CANopenNode_STM32
+    ${CMAKE_CURRENT_LIST_DIR}/../general
+)
+
+# Symbols for compilation
+set(symbols_SYMB ${symbols_SYMB}
+    "DEBUG"
+    "STM32F303xE"
+    "USE_FULL_LL_DRIVER"
+    "USE_HAL_DRIVER"
+)
+
+# Core MCU flags, CPU, instruction set and FPU setup
+# Set the global compilation flags for all units
+include(${CMAKE_CURRENT_LIST_DIR}/../../cmake/compiler-flags-cortex-m4.cmake)
+
+# Add executable
+add_executable(${CMAKE_PROJECT_NAME})
+target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC ${symbols_SYMB})
+target_include_directories(${CMAKE_PROJECT_NAME} PUBLIC ${include_DIRS})
+target_sources(${CMAKE_PROJECT_NAME} PUBLIC ${files_SRCS})
+
+# Setup linker parameters
+target_link_options(${CMAKE_PROJECT_NAME} PRIVATE
+    -T${linker_script_SRC}
+    ${cpu_PARAMS}
+    -Wl,-Map=${CMAKE_PROJECT_NAME}.map
+
+    -Wl,--start-group
+    -lc
+    -lm
+
+    -lstdc++
+    -lsupc++
+    -Wl,--end-group
+    -Wl,-z,max-page-size=8 # Allow good software remapping across address space (with proper GCC section making)
+    -Wl,--print-memory-usage
+)
+
+# Output files in the build folder
+set(BUILD_OUTPUT_DIR ${CMAKE_CURRENT_LIST_DIR}/../../_build_outputs)
+add_custom_command(TARGET ${CMAKE_PROJECT_NAME} POST_BUILD
+    COMMAND ${CMAKE_SIZE} $<TARGET_FILE:${CMAKE_PROJECT_NAME}>
+    COMMAND ${CMAKE_OBJCOPY} -O ihex $<TARGET_FILE:${CMAKE_PROJECT_NAME}> $<TARGET_FILE_DIR:${CMAKE_PROJECT_NAME}>/${CMAKE_PROJECT_NAME}.hex
+    COMMAND ${CMAKE_OBJCOPY} -O binary $<TARGET_FILE:${CMAKE_PROJECT_NAME}> $<TARGET_FILE_DIR:${CMAKE_PROJECT_NAME}>/${CMAKE_PROJECT_NAME}.bin
+)

--- a/examples/stm32f3xx_can/CMakePresets.json
+++ b/examples/stm32f3xx_can/CMakePresets.json
@@ -1,0 +1,27 @@
+{
+    "version": 3,
+    "configurePresets": [
+        {
+            "name": "default",
+            "hidden": true,
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build/${presetName}",
+            "toolchainFile": "${sourceDir}/../../cmake/gcc-arm-none-eabi.cmake",
+            "cacheVariables": {
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "name": "stm32f3xx_can",
+            "inherits": "default",
+            "cacheVariables": {}
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "stm32f3xx_can",
+            "configurePreset": "stm32f3xx_can"
+        }
+    ]
+}

--- a/examples/stm32f4xx_can/CMakeLists.txt
+++ b/examples/stm32f4xx_can/CMakeLists.txt
@@ -1,0 +1,79 @@
+cmake_minimum_required(VERSION 3.19)
+
+project(stm32f4xx_can)
+enable_language(C CXX ASM)
+
+# Linker and startup goes here
+set(linker_script_SRC ${CMAKE_CURRENT_LIST_DIR}/STM32F407VGTX_FLASH.ld)
+
+# Application, HAL driver and CANopenNode sources
+file(GLOB_RECURSE files_SRCS
+    ${CMAKE_CURRENT_LIST_DIR}/Core/Src/*.c
+    ${CMAKE_CURRENT_LIST_DIR}/Core/Startup/*.s
+    ${CMAKE_CURRENT_LIST_DIR}/Drivers/STM32F4xx_HAL_Driver/Src/*.c
+    ${CMAKE_CURRENT_LIST_DIR}/../../CANopenNode_STM32/*.c
+    ${CMAKE_CURRENT_LIST_DIR}/../general/*.c
+)
+file(GLOB_RECURSE canopennode_SRCS
+    ${CMAKE_CURRENT_LIST_DIR}/../../CANopenNode/*.c
+)
+
+# Ignore the actual example folder in the CanOpenNode object
+list(FILTER canopennode_SRCS EXCLUDE REGEX "/CANopenNode/example/")
+
+# Merge the sources
+set(files_SRCS ${files_SRCS} ${canopennode_SRCS})
+
+# Include directories
+set(include_DIRS ${include_DIRS}
+    ${CMAKE_CURRENT_LIST_DIR}/Core/Inc
+    ${CMAKE_CURRENT_LIST_DIR}/Drivers/STM32F4xx_HAL_Driver/Inc
+    ${CMAKE_CURRENT_LIST_DIR}/Drivers/STM32F4xx_HAL_Driver/Inc/Legacy
+    ${CMAKE_CURRENT_LIST_DIR}/Drivers/CMSIS/Device/ST/STM32F4xx/Include
+    ${CMAKE_CURRENT_LIST_DIR}/Drivers/CMSIS/Include
+    ${CMAKE_CURRENT_LIST_DIR}/../../CANopenNode
+    ${CMAKE_CURRENT_LIST_DIR}/../../CANopenNode_STM32
+    ${CMAKE_CURRENT_LIST_DIR}/../general
+)
+
+# Symbols for compilation
+set(symbols_SYMB ${symbols_SYMB}
+    "DEBUG"
+    "STM32F407xx"
+    "USE_HAL_DRIVER"
+)
+
+# Core MCU flags, CPU, instruction set and FPU setup
+# Set the global compilation flags for all units
+include(${CMAKE_CURRENT_LIST_DIR}/../../cmake/compiler-flags-cortex-m4.cmake)
+
+# Add executable
+add_executable(${CMAKE_PROJECT_NAME})
+target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC ${symbols_SYMB})
+target_include_directories(${CMAKE_PROJECT_NAME} PUBLIC ${include_DIRS})
+target_sources(${CMAKE_PROJECT_NAME} PUBLIC ${files_SRCS})
+
+# Setup linker parameters
+target_link_options(${CMAKE_PROJECT_NAME} PRIVATE
+    -T${linker_script_SRC}
+    ${cpu_PARAMS}
+    -Wl,-Map=${CMAKE_PROJECT_NAME}.map
+
+    -Wl,--start-group
+    -lc
+    -lm
+
+    -lstdc++
+    -lsupc++
+    -Wl,--end-group
+    -Wl,-z,max-page-size=8 # Allow good software remapping across address space (with proper GCC section making)
+    -Wl,--print-memory-usage
+)
+
+# Output files in the build folder
+set(BUILD_OUTPUT_DIR ${CMAKE_CURRENT_LIST_DIR}/../../_build_outputs)
+add_custom_command(TARGET ${CMAKE_PROJECT_NAME} POST_BUILD
+    COMMAND ${CMAKE_SIZE} $<TARGET_FILE:${CMAKE_PROJECT_NAME}>
+    COMMAND ${CMAKE_OBJCOPY} -O ihex $<TARGET_FILE:${CMAKE_PROJECT_NAME}> $<TARGET_FILE_DIR:${CMAKE_PROJECT_NAME}>/${CMAKE_PROJECT_NAME}.hex
+    COMMAND ${CMAKE_OBJCOPY} -O binary $<TARGET_FILE:${CMAKE_PROJECT_NAME}> $<TARGET_FILE_DIR:${CMAKE_PROJECT_NAME}>/${CMAKE_PROJECT_NAME}.bin
+)

--- a/examples/stm32f4xx_can/CMakePresets.json
+++ b/examples/stm32f4xx_can/CMakePresets.json
@@ -1,0 +1,27 @@
+{
+    "version": 3,
+    "configurePresets": [
+        {
+            "name": "default",
+            "hidden": true,
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build/${presetName}",
+            "toolchainFile": "${sourceDir}/../../cmake/gcc-arm-none-eabi.cmake",
+            "cacheVariables": {
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "name": "stm32f4xx_can",
+            "inherits": "default",
+            "cacheVariables": {}
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "stm32f4xx_can",
+            "configurePreset": "stm32f4xx_can"
+        }
+    ]
+}

--- a/examples/stm32g0xx_fdcan_rtos/CMakeLists.txt
+++ b/examples/stm32g0xx_fdcan_rtos/CMakeLists.txt
@@ -1,0 +1,83 @@
+cmake_minimum_required(VERSION 3.19)
+
+project(stm32g0xx_fdcan_rtos)
+enable_language(C CXX ASM)
+
+# Linker and startup goes here
+set(linker_script_SRC ${CMAKE_CURRENT_LIST_DIR}/STM32G0C1VETX_FLASH.ld)
+
+# Application, HAL driver and CANopenNode sources
+file(GLOB_RECURSE files_SRCS
+    ${CMAKE_CURRENT_LIST_DIR}/Core/Src/*.c
+    ${CMAKE_CURRENT_LIST_DIR}/Core/Startup/*.s
+    ${CMAKE_CURRENT_LIST_DIR}/Drivers/STM32G0xx_HAL_Driver/Src/*.c
+    ${CMAKE_CURRENT_LIST_DIR}/Middlewares/Third_Party/FreeRTOS/Source/*.c
+    ${CMAKE_CURRENT_LIST_DIR}/../../CANopenNode_STM32/*.c
+    ${CMAKE_CURRENT_LIST_DIR}/../general/*.c
+)
+file(GLOB_RECURSE canopennode_SRCS
+    ${CMAKE_CURRENT_LIST_DIR}/../../CANopenNode/*.c
+)
+
+# Ignore the actual example folder in the CanOpenNode object
+list(FILTER canopennode_SRCS EXCLUDE REGEX "/CANopenNode/example/")
+
+# Merge the sources
+set(files_SRCS ${files_SRCS} ${canopennode_SRCS})
+
+# Include directories
+set(include_DIRS ${include_DIRS}
+    ${CMAKE_CURRENT_LIST_DIR}/Core/Inc
+    ${CMAKE_CURRENT_LIST_DIR}/Drivers/STM32G0xx_HAL_Driver/Inc
+    ${CMAKE_CURRENT_LIST_DIR}/Drivers/STM32G0xx_HAL_Driver/Inc/Legacy
+    ${CMAKE_CURRENT_LIST_DIR}/Drivers/CMSIS/Device/ST/STM32G0xx/Include
+    ${CMAKE_CURRENT_LIST_DIR}/Drivers/CMSIS/Include
+    ${CMAKE_CURRENT_LIST_DIR}/Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS_V2
+    ${CMAKE_CURRENT_LIST_DIR}/Middlewares/Third_Party/FreeRTOS/Source/include
+    ${CMAKE_CURRENT_LIST_DIR}/Middlewares/Third_Party/FreeRTOS/Source/portable/GCC/ARM_CM0
+    ${CMAKE_CURRENT_LIST_DIR}/../../CANopenNode
+    ${CMAKE_CURRENT_LIST_DIR}/../../CANopenNode_STM32
+    ${CMAKE_CURRENT_LIST_DIR}/../general
+)
+
+# Symbols for compilation
+set(symbols_SYMB ${symbols_SYMB}
+    "DEBUG"
+    "STM32G0C1xx"
+    "USE_HAL_DRIVER"
+)
+
+# Core MCU flags, CPU, instruction set and FPU setup
+# Set the global compilation flags for all units
+include(${CMAKE_CURRENT_LIST_DIR}/../../cmake/compiler-flags-cortex-m0p.cmake)
+
+# Add executable
+add_executable(${CMAKE_PROJECT_NAME})
+target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC ${symbols_SYMB})
+target_include_directories(${CMAKE_PROJECT_NAME} PUBLIC ${include_DIRS})
+target_sources(${CMAKE_PROJECT_NAME} PUBLIC ${files_SRCS})
+
+# Setup linker parameters
+target_link_options(${CMAKE_PROJECT_NAME} PRIVATE
+    -T${linker_script_SRC}
+    ${cpu_PARAMS}
+    -Wl,-Map=${CMAKE_PROJECT_NAME}.map
+
+    -Wl,--start-group
+    -lc
+    -lm
+
+    -lstdc++
+    -lsupc++
+    -Wl,--end-group
+    -Wl,-z,max-page-size=8 # Allow good software remapping across address space (with proper GCC section making)
+    -Wl,--print-memory-usage
+)
+
+# Output files in the build folder
+set(BUILD_OUTPUT_DIR ${CMAKE_CURRENT_LIST_DIR}/../../_build_outputs)
+add_custom_command(TARGET ${CMAKE_PROJECT_NAME} POST_BUILD
+    COMMAND ${CMAKE_SIZE} $<TARGET_FILE:${CMAKE_PROJECT_NAME}>
+    COMMAND ${CMAKE_OBJCOPY} -O ihex $<TARGET_FILE:${CMAKE_PROJECT_NAME}> $<TARGET_FILE_DIR:${CMAKE_PROJECT_NAME}>/${CMAKE_PROJECT_NAME}.hex
+    COMMAND ${CMAKE_OBJCOPY} -O binary $<TARGET_FILE:${CMAKE_PROJECT_NAME}> $<TARGET_FILE_DIR:${CMAKE_PROJECT_NAME}>/${CMAKE_PROJECT_NAME}.bin
+)

--- a/examples/stm32g0xx_fdcan_rtos/CMakePresets.json
+++ b/examples/stm32g0xx_fdcan_rtos/CMakePresets.json
@@ -1,0 +1,27 @@
+{
+    "version": 3,
+    "configurePresets": [
+        {
+            "name": "default",
+            "hidden": true,
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build/${presetName}",
+            "toolchainFile": "${sourceDir}/../../cmake/gcc-arm-none-eabi.cmake",
+            "cacheVariables": {
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "name": "stm32g0xx_fdcan_rtos",
+            "inherits": "default",
+            "cacheVariables": {}
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "stm32g0xx_fdcan_rtos",
+            "configurePreset": "stm32g0xx_fdcan_rtos"
+        }
+    ]
+}

--- a/examples/stm32h7xx_fdcan/CMakeLists.txt
+++ b/examples/stm32h7xx_fdcan/CMakeLists.txt
@@ -1,0 +1,79 @@
+cmake_minimum_required(VERSION 3.19)
+
+project(stm32h7xx_fdcan)
+enable_language(C CXX ASM)
+
+# Linker and startup goes here
+set(linker_script_SRC ${CMAKE_CURRENT_LIST_DIR}/STM32H735IGKX_FLASH.ld)
+
+# Application, HAL driver and CANopenNode sources
+file(GLOB_RECURSE files_SRCS
+    ${CMAKE_CURRENT_LIST_DIR}/Core/Src/*.c
+    ${CMAKE_CURRENT_LIST_DIR}/Core/Startup/*.s
+    ${CMAKE_CURRENT_LIST_DIR}/Drivers/STM32H7xx_HAL_Driver/Src/*.c
+    ${CMAKE_CURRENT_LIST_DIR}/../../CANopenNode_STM32/*.c
+    ${CMAKE_CURRENT_LIST_DIR}/../general/*.c
+)
+file(GLOB_RECURSE canopennode_SRCS
+    ${CMAKE_CURRENT_LIST_DIR}/../../CANopenNode/*.c
+)
+
+# Ignore the actual example folder in the CanOpenNode object
+list(FILTER canopennode_SRCS EXCLUDE REGEX "/CANopenNode/example/")
+
+# Merge the sources
+set(files_SRCS ${files_SRCS} ${canopennode_SRCS})
+
+# Include directories
+set(include_DIRS ${include_DIRS}
+    ${CMAKE_CURRENT_LIST_DIR}/Core/Inc
+    ${CMAKE_CURRENT_LIST_DIR}/Drivers/STM32H7xx_HAL_Driver/Inc
+    ${CMAKE_CURRENT_LIST_DIR}/Drivers/STM32H7xx_HAL_Driver/Inc/Legacy
+    ${CMAKE_CURRENT_LIST_DIR}/Drivers/CMSIS/Device/ST/STM32H7xx/Include
+    ${CMAKE_CURRENT_LIST_DIR}/Drivers/CMSIS/Include
+    ${CMAKE_CURRENT_LIST_DIR}/../../CANopenNode
+    ${CMAKE_CURRENT_LIST_DIR}/../../CANopenNode_STM32
+    ${CMAKE_CURRENT_LIST_DIR}/../general
+)
+
+# Symbols for compilation
+set(symbols_SYMB ${symbols_SYMB}
+    "DEBUG"
+    "STM32H735xx"
+    "USE_HAL_DRIVER"
+)
+
+# Core MCU flags, CPU, instruction set and FPU setup
+# Set the global compilation flags for all units
+include(${CMAKE_CURRENT_LIST_DIR}/../../cmake/compiler-flags-cortex-m7.cmake)
+
+# Add executable
+add_executable(${CMAKE_PROJECT_NAME})
+target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC ${symbols_SYMB})
+target_include_directories(${CMAKE_PROJECT_NAME} PUBLIC ${include_DIRS})
+target_sources(${CMAKE_PROJECT_NAME} PUBLIC ${files_SRCS})
+
+# Setup linker parameters
+target_link_options(${CMAKE_PROJECT_NAME} PRIVATE
+    -T${linker_script_SRC}
+    ${cpu_PARAMS}
+    -Wl,-Map=${CMAKE_PROJECT_NAME}.map
+
+    -Wl,--start-group
+    -lc
+    -lm
+
+    -lstdc++
+    -lsupc++
+    -Wl,--end-group
+    -Wl,-z,max-page-size=8 # Allow good software remapping across address space (with proper GCC section making)
+    -Wl,--print-memory-usage
+)
+
+# Output files in the build folder
+set(BUILD_OUTPUT_DIR ${CMAKE_CURRENT_LIST_DIR}/../../_build_outputs)
+add_custom_command(TARGET ${CMAKE_PROJECT_NAME} POST_BUILD
+    COMMAND ${CMAKE_SIZE} $<TARGET_FILE:${CMAKE_PROJECT_NAME}>
+    COMMAND ${CMAKE_OBJCOPY} -O ihex $<TARGET_FILE:${CMAKE_PROJECT_NAME}> $<TARGET_FILE_DIR:${CMAKE_PROJECT_NAME}>/${CMAKE_PROJECT_NAME}.hex
+    COMMAND ${CMAKE_OBJCOPY} -O binary $<TARGET_FILE:${CMAKE_PROJECT_NAME}> $<TARGET_FILE_DIR:${CMAKE_PROJECT_NAME}>/${CMAKE_PROJECT_NAME}.bin
+)

--- a/examples/stm32h7xx_fdcan/CMakePresets.json
+++ b/examples/stm32h7xx_fdcan/CMakePresets.json
@@ -1,0 +1,27 @@
+{
+    "version": 3,
+    "configurePresets": [
+        {
+            "name": "default",
+            "hidden": true,
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build/${presetName}",
+            "toolchainFile": "${sourceDir}/../../cmake/gcc-arm-none-eabi.cmake",
+            "cacheVariables": {
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "name": "stm32h7xx_fdcan",
+            "inherits": "default",
+            "cacheVariables": {}
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "stm32h7xx_fdcan",
+            "configurePreset": "stm32h7xx_fdcan"
+        }
+    ]
+}


### PR DESCRIPTION
This PR adds cmake build system for all remaining projects. It is a 1to1 replication of the STM32CubeIDE project and allows easier build in the future in the docker. 

A baseline for CICD.