### PR TITLE
Fix fdcan array length

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Description
+
+<!-- Briefly describe what this PR changes and why -->
+
+## Related Issue
+
+<!-- Link to the issue this PR addresses, if any (e.g. Closes #123) -->
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Documentation update
+- [ ] Refactor / code cleanup
+
+## Checklist
+
+- [ ] I have tested the changes on a hardware
+- [ ] I have checked that the PR works for `CAN` and `FDCAN` devices, and explained if and why this rule deviates
+- [ ] I have performed the `python3 scripts/build.py` with success and no errors
+- [ ] I have checked and run `clang-format` with the repository input to format the code
+
+## Additional Notes
+
+<!-- Anything else reviewers should know -->

--- a/CANopenNode_STM32/CO_driver_STM32.c
+++ b/CANopenNode_STM32/CO_driver_STM32.c
@@ -40,9 +40,9 @@ static CO_CANmodule_t* CANModule_local = NULL; /* Local instance of global CAN m
 
 #ifdef CO_STM32_FDCAN_Driver
 #ifndef FDCAN_BUFFER_INDEXES
-#if defined (FDCAN_TX_BUFFER31)
+#if defined(FDCAN_TX_BUFFER31)
 #define FDCAN_BUFFER_INDEXES 0xFFFFFFFFU
-#elif defined (FDCAN_TX_BUFFER2)
+#elif defined(FDCAN_TX_BUFFER2)
 #define FDCAN_BUFFER_INDEXES FDCAN_TX_BUFFER0 | FDCAN_TX_BUFFER1 | FDCAN_TX_BUFFER2
 #else
 #define FDCAN_BUFFER_INDEXES 0xFFFFFFFFU
@@ -517,6 +517,14 @@ prv_read_can_received_msg(CAN_HandleTypeDef* hcan, uint32_t fifo, uint32_t fifo_
     uint8_t messageFound = 0;
 
 #ifdef CO_STM32_FDCAN_Driver
+
+    /*
+     * Write received message to the temporary 64-bytes buffer.
+     * This is to ensure that the CAN nodes that do not comply with the newer CAN standards
+     * don't send wrong message with the wrong DLC value. This is a safety measure to avoid buffer overflow.
+     * 
+     * Check the FDCAN implementation for STM32 in their respective reference manual.
+     */
     static FDCAN_RxHeaderTypeDef rx_hdr;
     static uint8_t rx_data[64];
     /* Read received message from FIFO */
@@ -657,7 +665,7 @@ HAL_FDCAN_TxBufferCompleteCallback(FDCAN_HandleTypeDef* hfdcan, uint32_t BufferI
                     CANModule_local->CANtxCount--;
                     CANModule_local->bufferInhibitFlag = buffer->syncFlag;
                 } else {
-                    break;  // if we could not send the message, break out of the loop (the tx buffers are full)
+                    break; // if we could not send the message, break out of the loop (the tx buffers are full)
                 }
             }
         }
@@ -716,9 +724,9 @@ CO_CANinterrupt_TX(CO_CANmodule_t* CANmodule, uint32_t MailboxNumber) {
                     buffer->bufferFull = false;
                     CANmodule->CANtxCount--;
                     CANmodule->bufferInhibitFlag = buffer->syncFlag;
+                } else {
+                    break; // if we could not send the message, break out of the loop (the tx buffers are full)
                 }
-                else
-                    break;  // if we could not send the message, break out of the loop (the tx buffers are full)
             }
         }
         CO_UNLOCK_CAN_SEND(CANmodule);

--- a/CANopenNode_STM32/CO_driver_STM32.c
+++ b/CANopenNode_STM32/CO_driver_STM32.c
@@ -518,8 +518,9 @@ prv_read_can_received_msg(CAN_HandleTypeDef* hcan, uint32_t fifo, uint32_t fifo_
 
 #ifdef CO_STM32_FDCAN_Driver
     static FDCAN_RxHeaderTypeDef rx_hdr;
+    static uint8_t rx_data[64];
     /* Read received message from FIFO */
-    if (HAL_FDCAN_GetRxMessage(hfdcan, fifo, &rx_hdr, rcvMsg.data) != HAL_OK) {
+    if (HAL_FDCAN_GetRxMessage(hfdcan, fifo, &rx_hdr, rx_data) != HAL_OK) {
         return;
     }
     /* Setup identifier (with RTR) and length */
@@ -555,6 +556,9 @@ prv_read_can_received_msg(CAN_HandleTypeDef* hcan, uint32_t fifo, uint32_t fifo_
         default:
             rcvMsg.dlc = 0;
             break; /* Invalid length when more than 8 */
+    }
+    if (rcvMsg.dlc > 0) {
+        memcpy(rcvMsg.data, rx_data, rcvMsg.dlc);
     }
     rcvMsgIdent = rcvMsg.ident;
 #else


### PR DESCRIPTION
This PR fixes issue https://github.com/CANopenNode/CanOpenSTM32/issues/123

In the STM32G0xx reference manual, chapter FDCAN, the structure of FDCAN Rx FIFO element is described as:
<img width="640" height="292" alt="image" src="https://github.com/user-attachments/assets/6b777aa8-a8ec-4223-9dcb-9bfff9c4d835" />

With DLC bits explained as:
<img width="551" height="90" alt="image" src="https://github.com/user-attachments/assets/5357b660-a3ca-4a46-81b5-055e9b5531e1" />

As CanOpen is only operating in the Classic CAN, we can be in a situation where data length code is between `9-15`, while the received message is only `8` bytes.

Such message could be legitimate simply because older (bxCAN) implementation may have wrongly set the reserved bit that indicated newer features for latest FDCAN implementation.

