### PR TITLE
fix: clang format indents the comments properly

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -140,7 +140,7 @@ PenaltyIndentedWhitespace: 0
 PointerAlignment: Left
 PPIndentWidth:   -1
 ReferenceAlignment: Pointer
-ReflowComments:  false
+ReflowComments:  Always
 RemoveBracesLLVM: false
 SeparateDefinitionBlocks: Always
 ShortNamespaceLines: 1


### PR DESCRIPTION
## Description

Fixes the wrong indent for the clang-format for comments

## Related Issue

<!-- Link to the issue this PR addresses, if any (e.g. Closes #123) -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Checklist

Please read [CONTRIBUTING.md](../CONTRIBUTING.md) for details on how to run each of the checks below.

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have tested the changes on a hardware
- [ ] I have checked that the PR works for `CAN` and `FDCAN` devices, and explained if and why this rule deviates
- [ ] I have performed the `python3 scripts/build.py` with success and no errors
- [ ] I have checked and run `clang-format` with the repository input to format the code
- [ ] I confirm I have completed all the applicable points above, or explained why they don't apply

## Additional Notes

<!-- Anything else reviewers should know -->